### PR TITLE
HS-642: Update to Kustomize 4.5.5

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @puppetlabs/saas-platform

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:latest
 RUN adduser kustomize -D \
   && apk add curl git openssh \
   && git config --global url.ssh://git@github.com/.insteadOf https://github.com/
-RUN  curl -L --output /tmp/kustomize_v3.3.0_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.3.0/kustomize_v3.3.0_linux_amd64.tar.gz \
-  && echo "4b49e1bbdb09851f11bb81081bfffddc7d4ad5f99b4be7ef378f6e3cf98d42b6  /tmp/kustomize_v3.3.0_linux_amd64.tar.gz" | sha256sum -c \
-  && tar -xvzf /tmp/kustomize_v3.3.0_linux_amd64.tar.gz -C /usr/local/bin \
+RUN  curl -L --output /tmp/kustomize_v4.5.5_linux_amd64.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.5/kustomize_v4.5.5_linux_amd64.tar.gz \
+  && echo "bba81aa61dba057db1d5abeddf1e522b568b2d906ab67a5c80935e97302c8773  /tmp/kustomize_v4.5.5_linux_amd64.tar.gz" | sha256sum -c \
+  && tar -xvzf /tmp/kustomize_v4.5.5_linux_amd64.tar.gz -C /usr/local/bin \
   && chmod +x /usr/local/bin/kustomize \
   && mkdir ~/.ssh \
   && ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ repos:
         args: [--allow-multiple-documents]
     -   id: check-added-large-files
 -   repo: https://github.com/puppetlabs/pre-commit-docker-kustomize
-    rev: v1.0.0
+    rev: v4.5.5
     hooks:
     -   id: kustomize
         name: kustomize-development

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pre-commit-docker-kustomize
-pre-commit hook which runs kustomize docker image. Docker image is based on https://github.com/lyft/kustomizer, but added github.com into known hosts and not running this image as root. This modification allows for remote refs in your kustomize. Other git providers will probably won't work and require further changes. Please raise an issue.
+This is a pre-commit hook forked from https://github.com/dmitri-lerko/pre-commit-docker-kustomize.
+
+Docker image is based on https://github.com/lyft/kustomizer, but added github.com into known hosts and not running this image as root. This modification allows for remote refs in your kustomize. Other git providers will probably won't work and require further changes. Please raise an issue.
 
 ## Example of .pre-commit-config.yaml that verifies that 3 overlays are not broken
 ```yaml
@@ -12,8 +14,8 @@ repos:
     -   id: check-yaml
         args: [--allow-multiple-documents]
     -   id: check-added-large-files
--   repo: https://github.com/dmitri-lerko/pre-commit-docker-kustomize
-    rev: f3a8533
+-   repo: https://github.com/puppetlabs/pre-commit-docker-kustomize
+    rev: v1.0.0
     hooks:
     -   id: kustomize
         name: kustomize-development


### PR DESCRIPTION
This updates to the most recent version of Kustomize and updates the README to refer to our fork with a version rather than a git SHA. I'm just going to make the version of the hook match the version of kustomize -- that seems like it's feasible, since there's not really much to the pre-commit hook anyway.